### PR TITLE
Fix(VC-819): Fix sa_family_t Declaration Error for Xcode 16 Compatibility

### DIFF
--- a/Source/CTSimplePingClient.h
+++ b/Source/CTSimplePingClient.h
@@ -49,6 +49,7 @@
 
 @import Foundation;
 
+#include <sys/socket.h>
 #include <AssertMacros.h>           // for __Check_Compile_Time
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
**Issue:** sa_family_t declaration missing in CTSimplePing causing build failures on Xcode 16.
![Screenshot 2024-09-02 at 6 57 41 PM (1)](https://github.com/user-attachments/assets/294995e3-0563-4a0c-8646-72a2e0bfd2ac)

**Solution:** Added `#import <sys/socket.h>` in CTSimplePing to resolve missing type errors.

**Impact:** Fixes build compatibility with Xcode 16.

**Tested on:** Xcode 16 Stable.


